### PR TITLE
Add toggle for TOC position style

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -449,6 +449,22 @@ export default class FloatingToc extends Plugin {
 				}
 			},
 		});
+		this.addCommand({
+			id: "toggle-position-style",
+			name: "Toggle Floating TOC Position (left/right)",
+			icon: "switch",
+			callback: () => {
+				if (this.settings.positionStyle === "left") {
+					this.settings.positionStyle = "right";
+				} else if (this.settings.positionStyle === "right") {
+					this.settings.positionStyle = "left";
+				} else if (this.settings.positionStyle === "both") {
+					new Notice("Position style set to both. Toogle position only works when fixed position (left or right) is selected.");
+				}
+				this.saveSettings();
+				dispatchEvent(new Event("refresh-toc"))
+			},
+		});
 		this.registerEvent(
 			this.app.workspace.on("active-leaf-change", () => {
 				let view = this.app.workspace.getActiveViewOfType(MarkdownView);


### PR DESCRIPTION
Resolves #99.

Introduced a new command to allow users to toggle the Floating Table of Contents (TOC) position between left and right. This enhancement provides a more flexible user experience by enabling quick adjustments to the TOC positioning directly from the interface, rather than delving into settings. It is especially useful for users who frequently change their workspace layout or work on different screens. The command is accessible through a 'Toggle Floating TOC Position (left/right)' command, with safeguards for cases where the position style is set to 'both', ensuring clarity and preventing confusion. This update aims at enhancing usability and customization for a smoother workflow, as allows macro calls from Commander, QuickAdd and others.